### PR TITLE
Add AE Sheet Mixin

### DIFF
--- a/scripts/AuraActiveEffectSheet.mjs
+++ b/scripts/AuraActiveEffectSheet.mjs
@@ -1,32 +1,34 @@
 import { getExtendedParts, getExtendedTabs } from "./helpers.mjs";
 
-export default class AuraActiveEffectSheet extends foundry.applications.sheets.ActiveEffectConfig {
-  static PARTS = getExtendedParts(super.PARTS);
+export default function ActiveEffectSheetMixin(ActiveEffectSheet) {
+  return class AuraActiveEffectSheet extends ActiveEffectSheet {
+    static PARTS = getExtendedParts(super.PARTS);
 
-  static TABS = getExtendedTabs(super.TABS);
+    static TABS = getExtendedTabs(super.TABS);
 
-  static DEFAULT_OPTIONS = {
-    actions: {
-      revert: AuraActiveEffectSheet.#onRevert
+    static DEFAULT_OPTIONS = {
+      actions: {
+        revert: AuraActiveEffectSheet.#onRevert
+      }
+    };
+
+    async _preparePartContext(id, context) {
+      context = await super._preparePartContext(id, context);
+      if (id === "aura") {
+        context = foundry.utils.mergeObject(context, {
+          fields: this.document.system.schema.fields
+        }, { inplace: false });
+      }
+      return context;
+    };
+
+    static #onRevert() {
+      const updates = this._processFormData(null, this.form, new foundry.applications.ux.FormDataExtended(this.form));
+      if (foundry.utils.getType(updates.changes) !== "Array") updates.changes = Object.values(updates.changes ?? {});
+      updates.type = this.document.getFlag("auraeffects", "originalType") ?? "base";
+      foundry.utils.setProperty(updates, "flags.-=auraeffects", null);
+      updates["==system"] = {};
+      this.document.update(updates);
     }
-  };
-
-  async _preparePartContext(id, context) {
-    context = await super._preparePartContext(id, context);
-    if (id === "aura") {
-      context = foundry.utils.mergeObject(context, {
-        fields: this.document.system.schema.fields
-      }, { inplace: false });
-    }
-    return context;
-  };
-
-  static #onRevert() {
-    const updates = this._processFormData(null, this.form, new foundry.applications.ux.FormDataExtended(this.form));
-    if (foundry.utils.getType(updates.changes) !== "Array") updates.changes = Object.values(updates.changes ?? {});
-    updates.type = this.document.getFlag("auraeffects", "originalType") ?? "base";
-    foundry.utils.setProperty(updates, "flags.-=auraeffects", null);
-    updates["==system"] = {};
-    this.document.update(updates);
   }
 }


### PR DESCRIPTION
This changes the extended class of AuraActiveEffectSheet from Foundry's ActiveEffectConfig to whichever is the default sheet class for the base AE document. This solves issues with modules/systems that have their own AE sheet with extra features.

I believe this turns the DAE replacement function obsolete (as long as the DAE Sheet is the default sheet), but I couldn't test it since I'm on V13.